### PR TITLE
fix: enforce PR approval for main branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-04-12
+
+### Fixed
+
+- Branch protection script: require PR with 1 approval and squash-only merges; fix pull_request rule schema for GitHub Rulesets API
+
 ## [1.2.0] - 2026-04-12
 
 ### Infrastructure

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "kiss-server"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kiss-server"
-version = "1.1.0"
+version = "1.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -31,7 +31,13 @@ cat > "$TMPFILE" << 'ENDJSON'
       "exclude": []
     }
   },
-  "bypass_actors": [],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ],
   "rules": [
     { "type": "deletion" },
     { "type": "non_fast_forward" },
@@ -42,6 +48,7 @@ cat > "$TMPFILE" << 'ENDJSON'
         "dismiss_stale_reviews_on_push": true,
         "require_code_owner_review": false,
         "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
         "allowed_merge_methods": ["squash"]
       }
     },

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -31,16 +31,20 @@ cat > "$TMPFILE" << 'ENDJSON'
       "exclude": []
     }
   },
-  "bypass_actors": [
-    {
-      "actor_type": "RepositoryRole",
-      "actor_id": 5,
-      "bypass_mode": "always"
-    }
-  ],
+  "bypass_actors": [],
   "rules": [
     { "type": "deletion" },
     { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "allowed_merge_methods": ["squash"]
+      }
+    },
     {
       "type": "required_status_checks",
       "parameters": {


### PR DESCRIPTION
## Summary

- Adds `pull_request` rule to the "Protect main" GitHub Ruleset requiring 1 approved review before merging
- Restricts merge method to squash-only
- Sets admin bypass mode to `pull_request` (admins still go through PRs, just don't need approval)
- Removes the previous `bypass_mode: always` that allowed direct pushes to main

## Test plan

- [ ] Verify this PR itself requires approval before merging (the rule is already live)
- [ ] Confirm `just branch-protection` re-applies cleanly if the ruleset ever needs resetting