### PR TITLE
docs: post-CloudFront documentation sweep (v1.2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,26 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
-- `README.md`: deployment URL updated to `https://www.ptodd.org/` (was HTTP); EC2 IP removed (no longer the public entry point behind CloudFront)
-- `docs/ci-cd.md`: "Setup from Scratch" section updated for post-CloudFront reality — ACM cert and CloudFront distribution steps added, DNS instructions updated from pre-cutover A-record setup to post-cutover CNAME-to-CloudFront, GitHub secrets expanded from 2 to 5 (adds `CLOUDFRONT_DISTRIBUTION_ID`, `CF_AWS_ACCESS_KEY_ID`, `CF_AWS_SECRET_ACCESS_KEY`)
+- `README.md`: deployment URL updated to `https://www.ptodd.org/` (was HTTP); EC2 IP removed (no
+  longer the public entry point behind CloudFront)
+- `docs/ci-cd.md`: "Setup from Scratch" section updated for post-CloudFront reality — ACM cert and
+  CloudFront distribution steps added, DNS instructions updated from pre-cutover A-record setup to
+  post-cutover CNAME-to-CloudFront, GitHub secrets expanded from 2 to 5 (adds
+  `CLOUDFRONT_DISTRIBUTION_ID`, `CF_AWS_ACCESS_KEY_ID`, `CF_AWS_SECRET_ACCESS_KEY`)
 - `CLAUDE.md`: test count corrected (86 → 88)
-- `src/main.rs`: crate-level docstring updated to reflect general-purpose HTTP server with CloudFront TLS termination
+- `src/main.rs`: crate-level docstring updated to reflect general-purpose HTTP server with
+  CloudFront TLS termination
 
-## [1.2.3] - 2026-04-13
+## [1.2.3] - 2026-04-12
 
 ### Changed
 
-- CD pipeline now triggers on semver tag push (`v*.*.*`) instead of prod branch push, eliminating the race condition where a branch sync could fire the deploy before a tag existed
-- `pre-deploy-check.sh`: added check that local `main` matches `origin/main` before tagging, preventing deployment of commits that haven't passed CI
+- CD pipeline now triggers on semver tag push (`v*.*.*`) instead of prod branch push, eliminating
+  the race condition where a branch sync could fire the deploy before a tag existed
+- `pre-deploy-check.sh`: added check that local `main` matches `origin/main` before tagging,
+  preventing deployment of commits that haven't passed CI
 - `just deploy-status` recipe: shows last 3 CD pipeline run outcomes from the CLI
-- CD pipeline: added `workflow_dispatch` trigger with tag input for manual re-runs without requiring a prod branch push
+- CD pipeline: added `workflow_dispatch` trigger with tag input for manual re-runs without requiring
+  a prod branch push
 
 ## [1.2.2] - 2026-04-12
 
 ### Added
 
 - `scripts/bump-version.sh`: automates Cargo.toml + Cargo.lock version bump with a release checklist
-- `scripts/pre-deploy-check.sh`: validates clean tree, main branch, version consistency, and CHANGELOG entry before deploy
+- `scripts/pre-deploy-check.sh`: validates clean tree, main branch, version consistency, and
+  CHANGELOG entry before deploy
 - `just bump VERSION` recipe for one-command version bumping
 - `just deploy VERSION` now runs pre-deploy checks before tagging
 
@@ -36,25 +45,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Branch protection script: require PR with 1 approval and squash-only merges; fix pull_request rule schema for GitHub Rulesets API
+- Branch protection script: require PR with 1 approval and squash-only merges; fix pull_request rule
+  schema for GitHub Rulesets API
 
 ## [1.2.0] - 2026-04-12
 
 ### Infrastructure
 
-- CloudFront distribution for HTTPS termination at edge via ACM certificate (ptodd.org, www.ptodd.org)
-- ACM certificate in us-east-1: auto-renewing DNS-validated certificate for ptodd.org and www.ptodd.org
-- CD pipeline: CloudFront cache invalidation (`/*`) after each successful deploy with least-privilege IAM credentials
-- DNS cutover: www.ptodd.org CNAME to CloudFront; ptodd.org apex 301-forwarded to https://www.ptodd.org
-- EC2 security group: port 80 restricted to CloudFront managed prefix list (direct public access removed)
-- Server: `Connection: close` header on all responses and 30-second read timeout for connection stability
+- CloudFront distribution for HTTPS termination at edge via ACM certificate (
+  ptodd.org, www.ptodd.org)
+- ACM certificate in us-east-1: auto-renewing DNS-validated certificate for ptodd.org
+  and www.ptodd.org
+- CD pipeline: CloudFront cache invalidation (`/*`) after each successful deploy with
+  least-privilege IAM credentials
+- DNS cutover: www.ptodd.org CNAME to CloudFront; ptodd.org apex 301-forwarded
+  to https://www.ptodd.org
+- EC2 security group: port 80 restricted to CloudFront managed prefix list (direct public access
+  removed)
+- Server: `Connection: close` header on all responses and 30-second read timeout for connection
+  stability
 
 ## [1.1.0] - 2026-03-25
 
 ### Added
 
-- Continuous deployment pipeline: push to `prod` branch triggers automated build, deploy to EC2, health check, and GitHub Release
-- Branch protection: main requires PR with passing CI; prod has deletion and non-fast-forward protection
+- Continuous deployment pipeline: push to `prod` branch triggers automated build, deploy to EC2,
+  health check, and GitHub Release
+- Branch protection: main requires PR with passing CI; prod has deletion and non-fast-forward
+  protection
 - AWS infrastructure: EC2 t3.micro with Elastic IP (54.83.192.65) and Security Group
 - EC2 service setup: systemd service, iptables port 80 to 8080 redirect, non-root execution
 - DNS configuration: ptodd.org and www.ptodd.org routed to EC2 via GoDaddy
@@ -76,7 +94,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HTTP/1.1 static file server built from scratch in pure Rust (stdlib + `log` crate only)
 - Handler, Context, and Router abstraction for request pipeline
 - Fixed-size thread pool for concurrent connection handling
-- Static file serving with binary-safe reads and MIME detection (10 types plus octet-stream fallback)
+- Static file serving with binary-safe reads and MIME detection (10 types plus octet-stream
+  fallback)
 - Path traversal prevention via canonicalize and starts_with check
 - Percent-encoding support for URL paths (RFC 3986 Section 2.1)
 - Directory requests serve index.html automatically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4] - 2026-04-12
+
+### Documentation
+
+- `README.md`: deployment URL updated to `https://www.ptodd.org/` (was HTTP); EC2 IP removed (no longer the public entry point behind CloudFront)
+- `docs/ci-cd.md`: "Setup from Scratch" section updated for post-CloudFront reality — ACM cert and CloudFront distribution steps added, DNS instructions updated from pre-cutover A-record setup to post-cutover CNAME-to-CloudFront, GitHub secrets expanded from 2 to 5 (adds `CLOUDFRONT_DISTRIBUTION_ID`, `CF_AWS_ACCESS_KEY_ID`, `CF_AWS_SECRET_ACCESS_KEY`)
+- `CLAUDE.md`: test count corrected (86 → 88)
+- `src/main.rs`: crate-level docstring updated to reflect general-purpose HTTP server with CloudFront TLS termination
+
 ## [1.2.3] - 2026-04-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ use `git push --force-with-lease` (not `--force`) to push the working branch.
 
 ## Testing
 
-All changes must pass `cargo test` (86 tests) before committing.
+All changes must pass `cargo test` (88 tests) before committing.
 Pre-commit hook runs the test suite automatically.
 
 ## Just Commands

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "kiss-server"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kiss-server"
-version = "1.2.3"
+version = "1.2.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ just docs          # Generate and open rustdoc in browser
 
 ## Deployment
 
-kiss-server is live at [http://ptodd.org/](http://ptodd.org/) on an EC2 t3.micro instance (54.83.192.65).
+kiss-server is live at [https://www.ptodd.org/](https://www.ptodd.org/) on an EC2 t3.micro behind CloudFront (ACM TLS, cache invalidation on deploy).
 
 To deploy, update CHANGELOG.md with the release notes, then run:
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -133,10 +133,11 @@ High-level steps to recreate the full infrastructure and pipeline from zero. See
 3. **ACM certificate:** Request a public cert in us-east-1 for `ptodd.org` and `www.ptodd.org`
    via AWS Certificate Manager. Validate via DNS (add the CNAME records GoDaddy side).
 
-4. **CloudFront distribution:** Create a distribution with the EC2 Elastic IP as origin (HTTP
-   port 80). Attach the ACM cert. Set `www.ptodd.org` as the alternate domain name. Enable
-   `Redirect HTTP to HTTPS` viewer policy. Run `scripts/setup-security-group.sh` to restrict
-   EC2 port 80 to the CloudFront managed prefix list.
+4. **CloudFront distribution:** Create a distribution with the EC2 public DNS name as origin
+   (the hostname that resolves to the Elastic IP, e.g., `ec2-54-83-192-65.compute-1.amazonaws.com`,
+   using HTTP port 80). Attach the ACM cert. Set `www.ptodd.org` as the alternate domain name.
+   Enable `Redirect HTTP to HTTPS` viewer policy. Run `scripts/setup-security-group.sh` to
+   restrict EC2 port 80 to the CloudFront managed prefix list.
 
 5. **DNS cutover:** In GoDaddy, add a CNAME for `www` pointing to the CloudFront domain
    (e.g., `d3ahc2eiiqz0iu.cloudfront.net`). Use a forwarding rule for the apex (`ptodd.org`)
@@ -152,8 +153,8 @@ High-level steps to recreate the full infrastructure and pipeline from zero. See
 7. **Branch protection:** Run `scripts/setup-branch-protection.sh` (protects `main`) and
    `scripts/setup-prod-protection.sh` (protects `prod`). Both require `gh` CLI authenticated.
 
-8. **Create prod branch:** `git push origin origin/main:prod` — this also triggers the first CD
-   deployment.
+8. **Create prod branch:** `git push origin origin/main:prod` — creates the tracking branch (does
+   not trigger CD). Then run `just deploy <VERSION>` to tag and trigger the first CD deployment.
 
 ## Just Recipes
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -130,17 +130,29 @@ High-level steps to recreate the full infrastructure and pipeline from zero. See
     - `scripts/setup-webroot.sh` — creates `/var/www/ptodd.org/` with Hello World index.html
     - `scripts/setup-iptables.sh` — configures port 80 to 8080 redirect
 
-3. **DNS:** Configure GoDaddy DNS: A record for `@` pointing to the Elastic IP, CNAME for `www`
-   pointing to `@`. Verify with `scripts/verify-dns.sh`.
+3. **ACM certificate:** Request a public cert in us-east-1 for `ptodd.org` and `www.ptodd.org`
+   via AWS Certificate Manager. Validate via DNS (add the CNAME records GoDaddy side).
 
-4. **GitHub secrets:** Add two repository secrets:
+4. **CloudFront distribution:** Create a distribution with the EC2 Elastic IP as origin (HTTP
+   port 80). Attach the ACM cert. Set `www.ptodd.org` as the alternate domain name. Enable
+   `Redirect HTTP to HTTPS` viewer policy. Run `scripts/setup-security-group.sh` to restrict
+   EC2 port 80 to the CloudFront managed prefix list.
+
+5. **DNS cutover:** In GoDaddy, add a CNAME for `www` pointing to the CloudFront domain
+   (e.g., `d3ahc2eiiqz0iu.cloudfront.net`). Use a forwarding rule for the apex (`ptodd.org`)
+   to redirect to `https://www.ptodd.org/`. Verify with `scripts/verify-dns.sh`.
+
+6. **GitHub secrets:** Add five repository secrets:
     - `EC2_SSH_KEY` — private key content for SSH access to EC2
     - `EC2_KNOWN_HOSTS` — EC2 host fingerprint (use `ssh-keyscan` output, not runtime TOFU)
+    - `CLOUDFRONT_DISTRIBUTION_ID` — the distribution ID (e.g., `E2JG60F8N1ZBAK`)
+    - `CF_AWS_ACCESS_KEY_ID` — IAM access key for the least-privilege CloudFront invalidation role
+    - `CF_AWS_SECRET_ACCESS_KEY` — corresponding IAM secret key
 
-5. **Branch protection:** Run `scripts/setup-branch-protection.sh` (protects `main`) and
+7. **Branch protection:** Run `scripts/setup-branch-protection.sh` (protects `main`) and
    `scripts/setup-prod-protection.sh` (protects `prod`). Both require `gh` CLI authenticated.
 
-6. **Create prod branch:** `git push origin origin/main:prod` — this also triggers the first CD
+8. **Create prod branch:** `git push origin origin/main:prod` — this also triggers the first CD
    deployment.
 
 ## Just Recipes

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
-//! Provides the backend implementation for the ptodd.org website.
+//! A from-scratch HTTP/1.1 static file server written in pure Rust.
+//! Runs behind CloudFront for TLS termination at ptodd.org / www.ptodd.org.
 
 use log::info;
 


### PR DESCRIPTION
## Problem

Several documentation files were left stale after the CloudFront/HTTPS milestone (phases 13–17) landed. The most impactful: the public-facing README still pointed to HTTP, the "Setup from Scratch" guide in `docs/ci-cd.md` described the pre-cutover DNS setup and was missing three required GitHub secrets for CloudFront invalidation, and a test count in `CLAUDE.md` had drifted.

## Changes

**`README.md`**
- Deployment URL updated from `http://ptodd.org/` to `https://www.ptodd.org/`
- EC2 IP removed — no longer the public entry point; security group now restricts direct access to CloudFront prefix list only
- Deployment description updated to mention CloudFront, ACM TLS, and cache invalidation

**`docs/ci-cd.md`** — Setup from Scratch section
- DNS step replaced with the correct post-cutover three-step sequence: ACM cert → CloudFront distribution → DNS CNAME cutover
- GitHub secrets expanded from 2 to 5: adds `CLOUDFRONT_DISTRIBUTION_ID`, `CF_AWS_ACCESS_KEY_ID`, `CF_AWS_SECRET_ACCESS_KEY` (all required by the CD pipeline but previously undocumented in the setup guide)
- Subsequent steps renumbered accordingly (6 steps → 8 steps)

**`CLAUDE.md`**
- Test count corrected: 86 → 88

**`src/main.rs`**
- Crate-level docstring updated from site-specific description to general-purpose HTTP server with CloudFront context

## Test plan

- [ ] `cargo test` passes (88 tests — verified locally)
- [ ] `README.md` deployment link resolves to `https://www.ptodd.org/` (HTTPS)
- [ ] `docs/ci-cd.md` Setup from Scratch steps are coherent end-to-end
- [ ] `CHANGELOG.md` contains `[1.2.4]` entry