### PR TITLE
fix: remove premature auth gate (v1.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-04-20
+
+### Changed
+
+- Removed `AuthMiddleware` from the default middleware chain — the site is intentionally public
+  and has no content requiring authentication yet; the auth gate was blocking all traffic after
+  the v1.5.0 deploy
+- Removed `KISS_SKIP_AUTH` escape hatch from `main.rs` (was a workaround for the above)
+
+### Auth Infrastructure
+
+The `AuthMiddleware`, `MiddlewareChain`, and `ctx.auth: Option<AuthClaims>` remain in place
+and are fully tested. Auth will be wired back into the chain when the first plugin requiring
+it ships (AUTH-02 strategy unchanged).
+
 ## [1.5.0] - 2026-04-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.1.0"
 
 [[package]]
 name = "kiss-server"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "kiss-plugin-sdk",
  "kiss-url-shortener",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "kiss-server"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2024"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use kiss_url_shortener::UrlShortener;
 use log::info;
 
 use logger::SimpleLogger;
-use server::{AuthMiddleware, MiddlewareChain, Router, Server};
+use server::{MiddlewareChain, Router, Server};
 
 mod args;
 mod config;
@@ -130,17 +130,7 @@ fn main() -> Result<()> {
         }
     }
 
-    let skip_auth = std::env::var("KISS_SKIP_AUTH")
-        .map(|v| !matches!(v.to_ascii_lowercase().as_str(), "0" | "false" | "no"))
-        .unwrap_or(false);
-    let middleware_chain = if skip_auth {
-        info!("KISS_SKIP_AUTH set — auth middleware disabled (dev mode only)");
-        MiddlewareChain::new().public_routes(&[])
-    } else {
-        MiddlewareChain::new()
-            .add(AuthMiddleware::new())
-            .public_routes(&["/health", "/favicon.ico"])
-    };
+    let middleware_chain = MiddlewareChain::new();
 
     Server::new(&addr)?
         .with_router(router)

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -16,9 +16,11 @@ use super::{
 /// The Rust server trusts it because only CloudFront can reach the origin.
 /// Direct-to-origin access bypasses auth — accepted because an EC2 security group
 /// restricts port 80 to CloudFront IP ranges only (Phase 17, T-22-01).
+#[allow(dead_code)]
 pub struct AuthMiddleware;
 
 impl AuthMiddleware {
+    #[allow(dead_code)]
     pub fn new() -> Self {
         AuthMiddleware
     }

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -7,6 +7,7 @@ pub enum MiddlewareResult {
     /// Continue to the next middleware (or to dispatch if last).
     Continue,
     /// Stop the chain — middleware has written ctx.response.
+    #[allow(dead_code)]
     ShortCircuit,
 }
 
@@ -52,6 +53,7 @@ impl MiddlewareChain {
     }
 
     /// Register a middleware (value-chaining builder).
+    #[allow(dead_code)]
     pub fn add(mut self, m: impl Middleware + 'static) -> Self {
         self.middleware.push(Box::new(m));
         self
@@ -61,6 +63,7 @@ impl MiddlewareChain {
     ///
     /// Routes on this list bypass all middleware entirely. Comparison is
     /// exact-match against the percent-decoded request path (D-05).
+    #[allow(dead_code)]
     pub fn public_routes(mut self, routes: &[&str]) -> Self {
         self.public_routes = routes.iter().map(|s| s.to_string()).collect();
         self

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -14,6 +14,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[allow(unused_imports)]
 pub use auth::AuthMiddleware;
 #[allow(unused_imports)]
 pub use context::AuthClaims;


### PR DESCRIPTION
## Summary

- Removes `AuthMiddleware` from the default middleware chain in `main.rs` — the site is intentionally public and has no content requiring authentication yet
- Removes the `KISS_SKIP_AUTH` escape hatch (it was a workaround for the above)
- Adds `#[allow(dead_code)]` to auth/middleware infrastructure so it compiles cleanly without warnings

## Background

v1.5.0 shipped `AuthMiddleware` wired as the default gate on all routes. This required a `X-Authenticated-User` header injected by Lambda@Edge — which was never built. The result: every request to ptodd.org returned 401 Unauthorized immediately after the deploy.

Hotfixed in production by setting `KISS_SKIP_AUTH=true` in the systemd unit; this PR makes the fix permanent and removes the escape hatch.

Auth infrastructure (`AuthMiddleware`, `MiddlewareChain`, `ctx.auth: Option<AuthClaims>`) is fully preserved and tested. It will be re-wired when the first plugin requiring authentication ships (AUTH-02).

## Test plan

- [x] `just lint` — zero warnings
- [x] `just test` — 190 tests pass
- [ ] Merge → CD pipeline builds and deploys v1.5.1 to prod
- [ ] Remove `KISS_SKIP_AUTH=true` from EC2 systemd unit after deploy